### PR TITLE
Documentation for conductance-displacement histograms.

### DIFF
--- a/doc/4-electron-transport.dox
+++ b/doc/4-electron-transport.dox
@@ -83,6 +83,13 @@ Transport observables are defined in electron_transport/simulator_models/observa
    \if fullref
    - Implemented by the class molstat::transport::ZeroBiasConductance.
    \endif
+   
+- Width (Distance)
+   - W
+   - Name (for use in input) is `%Distance`.
+   \if fullref
+   - Implemented by the class molstat::transport::Distance.
+   \endif   
 
 \subsection subsec_transport_simulate_models Models for Simulating Electron Transport
 \if fullref
@@ -209,9 +216,9 @@ Complete details for each of these channel models can be found in the full refer
    \f]
    \if fullref
    - Implemented by the class molstat::transport::RectangularBarrier; full details are presented there.
-   - Compatible with the molstat::transport::ZeroBiasConductance observable.
+   - Compatible with the molstat::transport::ZeroBiasConductance, molstat::transport::StaticConductance, and molstat::transport::ZeroBiasConductance observables.
    \elseif userman
-   - Compatible with the ZeroBiasConductance observable.
+   - Compatible with the ZeroBiasConductance, StaticConductance, and Distance observables.
    \endif
 
 \section sec_fit_electron_transport Fitting Electron Transport Properties


### PR DESCRIPTION
Added distance observable and added compatibility of the rectangular barrier model with the static conductance and distance observable to documentation. 

I noticed that in the rectangular barrier model, barrier width is denoted by width. As such, I have called the distance observable width with distance in parentheses. Do you think this will cause any confusion? If so, I can simply change the name of the distance class to width.
